### PR TITLE
Bumping up jackson version 

### DIFF
--- a/htrace-core4/pom.xml
+++ b/htrace-core4/pom.xml
@@ -94,10 +94,12 @@ language governing permissions and limitations under the License. -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
     </dependency>
     <!-- core specific deps. -->
     <dependency>

--- a/htrace-hbase/src/test/java/org/apache/htrace/impl/TestHBaseSpanReceiver.java
+++ b/htrace-hbase/src/test/java/org/apache/htrace/impl/TestHBaseSpanReceiver.java
@@ -61,7 +61,7 @@ public class TestHBaseSpanReceiver {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    UTIL.startMiniCluster(1);
+    UTIL.startMiniCluster();
   }
 
   @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,6 @@ language governing permissions and limitations under the License. -->
   <modules>
     <module>htrace-c</module>
     <module>htrace-core4</module>
-    <module>htrace-webapp</module>
-    <module>htrace-zipkin</module>
-    <module>htrace-hbase</module>
-    <module>htrace-flume</module>
-    <module>htrace-htraced</module>
-    <module>htrace-kudu</module>
   </modules>
 
   <scm>
@@ -308,7 +302,7 @@ language governing permissions and limitations under the License. -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.4.0</version>
+        <version>2.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
- addressing jackson-databind related vulnerabilities for htrace-core. see details [here](https://wwwin-github.cisco.com/CPSG/cmo-so-anchore-scan/pull/136#issuecomment-1210845).